### PR TITLE
Fix: use all of stdin, not only 1st line

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,12 +18,9 @@ pub fn read_from_stdin() -> Result<String> {
     std::io::stdin()
         .lock()
         .lines()
-        .next()
-        .unwrap()
-        .map_err(|e| {
-            eprintln!("{}", e);
-            Error::StdinError
-        })
+        .collect::<std::result::Result<Vec<_>, std::io::Error>>()
+        .and_then(|lines| Ok(lines.join("\n")))
+        .or(Err(Error::StdinError))
 }
 
 pub fn remove_file<P: AsRef<Path>>(p: P) -> Result {


### PR DESCRIPTION
Greetings!

Thank you for publishing such a nice package.

When trying it, I found this bug:

```
$ { echo foo; echo bar; } | pf
https://paste.rs/gjc 
$ curl -s https://paste.rs/gjc
foo$ : -- where's the bar ???
```

In words: when used with stdin, only the 1st line is pasted; the rest is ignored. Which is kinda useless if you think about it; what for people mostly use pastebin tools? For transferring/sharing _big text dumps_. If you were to share a single-line text — would you send a link to the paste of the line, or just the line itself directly?

Here's also my patch to fix this, I hope you like it, merge & release. Best wishes