### PR TITLE
Fix some clippy lints

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,6 @@ fn main() {
                     } else {
                         println!("{} ", &*PastFile::fetch(&*u).unwrap());
                     }
-                    return;
                 } else {
                     eprintln!("url not valid");
                     process::exit(1);
@@ -51,7 +50,6 @@ fn main() {
             CREATE(p) => {
                 if let Ok(resp_url) = PastFile::create(utils::read_file(p).unwrap()) {
                     println!("{} ", resp_url);
-                    return;
                 } else {
                     eprintln!("error post file");
                     process::exit(1);
@@ -60,7 +58,6 @@ fn main() {
             DELETE(u) => {
                 if let Ok(o) = PastFile::delete(&*u) {
                     println!("{} ", o);
-                    return;
                 } else {
                     eprintln!("unsuccessful delete file");
                     process::exit(1);

--- a/src/request.rs
+++ b/src/request.rs
@@ -19,7 +19,7 @@ impl PastFile {
                         .expect("failed read response");
                     info!("FETCH : {:?} ", url.trim());
                     out = out.trim().to_owned();
-                    return Ok(out);
+                    Ok(out)
                 } else {
                     panic!("unsuccessful request !")
                 }
@@ -40,7 +40,7 @@ impl PastFile {
                         .expect("failed read response");
                     out = out.trim().to_owned();
                     info!("CREATE : {:?} ", out);
-                    return Ok(out);
+                    Ok(out)
                 } else {
                     panic!("unsuccessful create request !")
                 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,8 +18,7 @@ pub fn read_from_stdin() -> Result<String> {
     std::io::stdin()
         .lock()
         .lines()
-        .collect::<std::result::Result<Vec<_>, std::io::Error>>()
-        .and_then(|lines| Ok(lines.join("\n")))
+        .collect::<std::result::Result<Vec<_>, std::io::Error>>().map(|lines| lines.join("\n"))
         .or(Err(Error::StdinError))
 }
 


### PR DESCRIPTION
Fixes some easy clippy lints:

- unneeded return statements in main.rs and request.rs
- changing a .and_then() from Result to a .map() in utils.rs